### PR TITLE
Hotfix: Update deployment configurations for local and prod environments

### DIFF
--- a/.k8s/tavernhelios-ingress copy.yaml
+++ b/.k8s/tavernhelios-ingress copy.yaml
@@ -5,24 +5,20 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"  
 spec:
-  ingressClassName: nginx
-  tls:
-    - hosts:
-        - heliostavern.local
-      secretName: tavernhelios-tls
+  ingressClassName: nginx 
   rules:
     - host: heliostavern.local
       http:
         paths:
+          # Бэкенд работает по HTTP
           - path: /api
             pathType: Prefix
             backend:
               service:
                 name: tavernhelios-server-service
                 port:
-                  number: 8080  
+                  number: 5040
 
           - path: /
             pathType: Prefix
@@ -30,7 +26,7 @@ spec:
               service:
                 name: tavernhelios-server-service
                 port:
-                  number: 8080  
+                  number: 5040
 
           # gRPC-сервисы
           - path: /menu
@@ -39,7 +35,7 @@ spec:
               service:
                 name: menuservice
                 port:
-                  number: 5064
+                  number: 5064 
 
           - path: /reservation
             pathType: Prefix
@@ -47,4 +43,4 @@ spec:
               service:
                 name: reservationservice
                 port:
-                  number: 5065
+                  number: 5065 

--- a/.k8s/tavernhelios-ingress.yaml
+++ b/.k8s/tavernhelios-ingress.yaml
@@ -5,24 +5,20 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"  
 spec:
-  ingressClassName: nginx
-  tls:
-    - hosts:
-        - heliostavern.local
-      secretName: tavernhelios-tls
+  ingressClassName: nginx 
   rules:
     - host: heliostavern.local
       http:
         paths:
+          # Бэкенд работает по HTTP
           - path: /api
             pathType: Prefix
             backend:
               service:
                 name: tavernhelios-server-service
                 port:
-                  number: 8080  
+                  number: 8080
 
           - path: /
             pathType: Prefix
@@ -30,7 +26,7 @@ spec:
               service:
                 name: tavernhelios-server-service
                 port:
-                  number: 8080  
+                  number: 8080
 
           # gRPC-сервисы
           - path: /menu
@@ -39,7 +35,7 @@ spec:
               service:
                 name: menuservice
                 port:
-                  number: 5064
+                  number: 5064 
 
           - path: /reservation
             pathType: Prefix
@@ -47,4 +43,4 @@ spec:
               service:
                 name: reservationservice
                 port:
-                  number: 5065
+                  number: 5065 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS with-node
 RUN apt-get update
 RUN apt-get install curl
-RUN curl -sL https://deb.nodesource.com/setup_23.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
 RUN apt-get -y install nodejs
 
 # Сборка проекта (бэкенд + фронт)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,50 @@
-# См. статью по ссылке https://aka.ms/customizecontainer, чтобы узнать как настроить контейнер отладки и как Visual Studio использует этот Dockerfile для создания образов для ускорения отладки.
+# # См. статью по ссылке https://aka.ms/customizecontainer, чтобы узнать как настроить контейнер отладки и как Visual Studio использует этот Dockerfile для создания образов для ускорения отладки.
 
-# Этот этап используется при запуске из VS в быстром режиме (по умолчанию для конфигурации отладки)
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-USER $APP_UID
-WORKDIR /app
-EXPOSE 8080
-EXPOSE 8081
+# # Этот этап используется при запуске из VS в быстром режиме (по умолчанию для конфигурации отладки)
+# FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+# USER $APP_UID
+# WORKDIR /app
+# EXPOSE 8080
+# EXPOSE 8081
 
 
-# Этот этап используется для сборки проекта службы
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS with-node
-RUN apt-get update
-RUN apt-get install curl
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
-RUN apt-get -y install nodejs
+# # Этот этап используется для сборки проекта службы
+# FROM mcr.microsoft.com/dotnet/sdk:8.0 AS with-node
+# RUN apt-get update
+# RUN apt-get install curl
+# RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
+# RUN apt-get -y install nodejs
 
-# Сборка проекта (бэкенд + фронт)
-FROM with-node AS build
-ARG BUILD_CONFIGURATION=Release
-ARG VITE_APP_VERSION
+# # Сборка проекта (бэкенд + фронт)
+# FROM with-node AS build
+# ARG BUILD_CONFIGURATION=Release
+# ARG VITE_APP_VERSION
 
-WORKDIR /src
-COPY ["TavernHelios.Server/TavernHelios.Server.csproj", "TavernHelios.Server/"]
-COPY ["tavernhelios.client/tavernhelios.client.esproj", "tavernhelios.client/"]
-RUN dotnet restore "./TavernHelios.Server/TavernHelios.Server.csproj"
-COPY . .
+# WORKDIR /src
+# COPY ["TavernHelios.Server/TavernHelios.Server.csproj", "TavernHelios.Server/"]
+# COPY ["tavernhelios.client/tavernhelios.client.esproj", "tavernhelios.client/"]
+# RUN dotnet restore "./TavernHelios.Server/TavernHelios.Server.csproj"
+# COPY . .
 
-# Обновляем .env с версией во фронтенде
-WORKDIR "/src/tavernhelios.client"
-RUN echo "VITE_APP_VERSION=$VITE_APP_VERSION" > .env  
-RUN npm install
-RUN npm run build
+# # Обновляем .env с версией во фронтенде
+# WORKDIR "/src/tavernhelios.client"
+# RUN echo "VITE_APP_VERSION=$VITE_APP_VERSION" > .env  
+# RUN npm install
+# RUN npm run build
 
-WORKDIR "/src/TavernHelios.Server"
-RUN dotnet build "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/build
+# WORKDIR "/src/TavernHelios.Server"
+# RUN dotnet build "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
-# Этот этап используется для публикации проекта службы, который будет скопирован на последний этап
-FROM build AS publish
-ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+# # Этот этап используется для публикации проекта службы, который будет скопирован на последний этап
+# FROM build AS publish
+# ARG BUILD_CONFIGURATION=Release
+# RUN dotnet publish "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
-# Этот этап используется в рабочей среде или при запуске из VS в обычном режиме  (по умолчанию, когда конфигурация отладки не используется)
-FROM base AS final
-WORKDIR /app
-COPY --from=publish /app/publish .
+# # Этот этап используется в рабочей среде или при запуске из VS в обычном режиме  (по умолчанию, когда конфигурация отладки не используется)
+# FROM base AS final
+# WORKDIR /app
+# COPY --from=publish /app/publish .
 
-ENV APP_VERSION=$VITE_APP_VERSION
+# ENV APP_VERSION=$VITE_APP_VERSION
 
-ENTRYPOINT ["dotnet", "TavernHelios.Server.dll"]
+# ENTRYPOINT ["dotnet", "TavernHelios.Server.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS with-node
 RUN apt-get update
 RUN apt-get install curl
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_23.x | bash
 RUN apt-get -y install nodejs
 
 # Сборка проекта (бэкенд + фронт)
@@ -36,6 +36,8 @@ RUN npm install
 RUN npm run build
 
 WORKDIR "/src/TavernHelios.Server"
+RUN mkdir -p /app/wwwroot
+RUN cp -r /src/tavernhelios.client/dist/* /app/wwwroot/
 RUN dotnet build "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 # Этот этап используется для публикации проекта службы, который будет скопирован на последний этап
@@ -47,7 +49,7 @@ RUN dotnet publish "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /ap
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+COPY --from=build /app/wwwroot /app/wwwroot
 
 ENV APP_VERSION=$VITE_APP_VERSION
-
 ENTRYPOINT ["dotnet", "TavernHelios.Server.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,53 @@
-# # См. статью по ссылке https://aka.ms/customizecontainer, чтобы узнать как настроить контейнер отладки и как Visual Studio использует этот Dockerfile для создания образов для ускорения отладки.
+# См. статью по ссылке https://aka.ms/customizecontainer, чтобы узнать как настроить контейнер отладки и как Visual Studio использует этот Dockerfile для создания образов для ускорения отладки.
 
-# # Этот этап используется при запуске из VS в быстром режиме (по умолчанию для конфигурации отладки)
-# FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-# USER $APP_UID
-# WORKDIR /app
-# EXPOSE 8080
-# EXPOSE 8081
+# Этот этап используется при запуске из VS в быстром режиме (по умолчанию для конфигурации отладки)
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
 
 
-# # Этот этап используется для сборки проекта службы
-# FROM mcr.microsoft.com/dotnet/sdk:8.0 AS with-node
-# RUN apt-get update
-# RUN apt-get install curl
-# RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
-# RUN apt-get -y install nodejs
+# Этот этап используется для сборки проекта службы
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS with-node
+RUN apt-get update
+RUN apt-get install curl
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
+RUN apt-get -y install nodejs
 
-# # Сборка проекта (бэкенд + фронт)
-# FROM with-node AS build
-# ARG BUILD_CONFIGURATION=Release
-# ARG VITE_APP_VERSION
+# Сборка проекта (бэкенд + фронт)
+FROM with-node AS build
+ARG BUILD_CONFIGURATION=Release
+ARG VITE_APP_VERSION
 
-# WORKDIR /src
-# COPY ["TavernHelios.Server/TavernHelios.Server.csproj", "TavernHelios.Server/"]
-# COPY ["tavernhelios.client/tavernhelios.client.esproj", "tavernhelios.client/"]
-# RUN dotnet restore "./TavernHelios.Server/TavernHelios.Server.csproj"
-# COPY . .
+WORKDIR /src
+COPY ["TavernHelios.Server/TavernHelios.Server.csproj", "TavernHelios.Server/"]
+COPY ["tavernhelios.client/tavernhelios.client.esproj", "tavernhelios.client/"]
+COPY ["Common/TavernHelios.GrpcCommon/TavernHelios.GrpcCommon.csproj", "Common/TavernHelios.GrpcCommon/"]
+COPY ["MenuService/APICore/TavernHelios.MenuService.APICore.csproj", "MenuService/APICore/"]
+COPY ["ReservationService/TavernHelios.ReservationService.APICore/TavernHelios.ReservationService.APICore.csproj", "ReservationService/TavernHelios.ReservationService.APICore/"]
+RUN dotnet restore "./TavernHelios.Server/TavernHelios.Server.csproj"
+COPY . .
 
-# # Обновляем .env с версией во фронтенде
-# WORKDIR "/src/tavernhelios.client"
-# RUN echo "VITE_APP_VERSION=$VITE_APP_VERSION" > .env  
-# RUN npm install
-# RUN npm run build
+# Обновляем .env с версией во фронтенде
+WORKDIR "/src/tavernhelios.client"
+RUN echo "VITE_APP_VERSION=$VITE_APP_VERSION" > .env  
+RUN npm install
+RUN npm run build
 
-# WORKDIR "/src/TavernHelios.Server"
-# RUN dotnet build "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/build
+WORKDIR "/src/TavernHelios.Server"
+RUN dotnet build "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
-# # Этот этап используется для публикации проекта службы, который будет скопирован на последний этап
-# FROM build AS publish
-# ARG BUILD_CONFIGURATION=Release
-# RUN dotnet publish "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+# Этот этап используется для публикации проекта службы, который будет скопирован на последний этап
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
-# # Этот этап используется в рабочей среде или при запуске из VS в обычном режиме  (по умолчанию, когда конфигурация отладки не используется)
-# FROM base AS final
-# WORKDIR /app
-# COPY --from=publish /app/publish .
+# Этот этап используется в рабочей среде или при запуске из VS в обычном режиме  (по умолчанию, когда конфигурация отладки не используется)
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
 
-# ENV APP_VERSION=$VITE_APP_VERSION
+ENV APP_VERSION=$VITE_APP_VERSION
 
-# ENTRYPOINT ["dotnet", "TavernHelios.Server.dll"]
+ENTRYPOINT ["dotnet", "TavernHelios.Server.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS with-node
 RUN apt-get update
 RUN apt-get install curl
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_23.x | bash
 RUN apt-get -y install nodejs
 
 # Сборка проекта (бэкенд + фронт)

--- a/Dockerfile copy
+++ b/Dockerfile copy
@@ -1,0 +1,52 @@
+# См. статью по ссылке https://aka.ms/customizecontainer, чтобы узнать как настроить контейнер отладки и как Visual Studio использует этот Dockerfile для создания образов для ускорения отладки.
+
+# Этот этап используется при запуске из VS в быстром режиме (по умолчанию для конфигурации отладки)
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+
+# Этот этап используется для сборки проекта службы
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS with-node
+RUN apt-get update
+RUN apt-get install curl
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash
+RUN apt-get -y install nodejs
+
+# Сборка проекта (бэкенд + фронт)
+FROM with-node AS build
+ARG BUILD_CONFIGURATION=Release
+ARG VITE_APP_VERSION
+
+COPY ["TavernHelios.Server/TavernHelios.Server.csproj", "TavernHelios.Server/"]
+COPY ["tavernhelios.client/tavernhelios.client.esproj", "tavernhelios.client/"]
+COPY ["Common/TavernHelios.GrpcCommon/TavernHelios.GrpcCommon.csproj", "Common/TavernHelios.GrpcCommon/"]
+COPY ["MenuService/APICore/TavernHelios.MenuService.APICore.csproj", "MenuService/APICore/"]
+COPY ["ReservationService/TavernHelios.ReservationService.APICore/TavernHelios.ReservationService.APICore.csproj", "ReservationService/TavernHelios.ReservationService.APICore/"]
+RUN dotnet restore "./TavernHelios.Server/TavernHelios.Server.csproj"
+COPY . .
+
+# Обновляем .env с версией во фронтенде
+WORKDIR "/src/tavernhelios.client"
+RUN echo "VITE_APP_VERSION=$VITE_APP_VERSION" > .env  
+RUN npm install
+RUN npm run build
+
+WORKDIR "/src/TavernHelios.Server"
+RUN dotnet build "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+# Этот этап используется для публикации проекта службы, который будет скопирован на последний этап
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./TavernHelios.Server.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+# Этот этап используется в рабочей среде или при запуске из VS в обычном режиме  (по умолчанию, когда конфигурация отладки не используется)
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+
+ENV APP_VERSION=$VITE_APP_VERSION
+
+ENTRYPOINT ["dotnet", "TavernHelios.Server.dll"]

--- a/PowerShell/docker.ps1
+++ b/PowerShell/docker.ps1
@@ -1,3 +1,17 @@
+docker down
+docker-compose down
+docker-compose up --build -d
+
+docker network inspect app_network
+docker network rm app_network
+docker network create --driver bridge --attachable app_network
+docker network connect app_network TavernHelios.Server_2
+
+
+
+docker exec -it TavernHelios.Server sh
+
+
 docker build -t heliostavern-frontend .
 docker run -d -p 63049:80 --name TavernHelios.Client heliostavern-frontend
 
@@ -6,7 +20,7 @@ docker build -t heliostavern-backend:latest -f TavernHelios.Server/Dockerfile D:
 docker run -d -p 8080:8080 --name heliostavern-backend heliostavern-backend:latest
 
 
-docker down
+
 
 
 
@@ -47,7 +61,3 @@ kubectl get pods
 kubectl exec -it tavernhelios-server-84575cf97-6kwbx -- env | grep VITE_API_URL
 
 
-
-docker exec -it TavernHelios.Server sh
-
-curl -v --http2-prior-knowledge http://host.docker.internal:5064

--- a/PowerShell/gRPC.ps1
+++ b/PowerShell/gRPC.ps1
@@ -22,3 +22,4 @@ grpcurl -plaintext 178.72.83.217:32042 describe TavernHelios.GrpcContract.Reserv
 docker exec -it menuService curl -v --http2-prior-knowledge http://localhost:5064
 docker exec -it ReservationService curl -v --http2-prior-knowledge http://localhost:5066
 
+curl -v --http2-prior-knowledge http://host.docker.internal:5064

--- a/TavernHelios.Server/Program.cs
+++ b/TavernHelios.Server/Program.cs
@@ -15,7 +15,7 @@ namespace TavernHelios.Server
                 options.AddPolicy("AllowFrontend",
                     builder =>
                     {
-                        builder.WithOrigins("https://localhost:63049", "https://localhost:5555", "https://localhost:8888") // ��������� ��������� ����������
+                        builder.WithOrigins("https://localhost:63049", "https://localhost:5555", "https://localhost:8888", "http://178.72.83.217:32040") // ��������� ��������� ����������
                                .AllowAnyMethod()
                                .AllowAnyHeader()
                                .AllowAnyOrigin();

--- a/TavernHelios.Server/Properties/launchSettings.json
+++ b/TavernHelios.Server/Properties/launchSettings.json
@@ -35,6 +35,7 @@
       "commandName": "Docker",
       "launchBrowser": true,
       "launchUrl": "{Scheme}://localhost:5555/swagger",
+      "dockerNetwork": "app_network",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_USE_POLLING_FILE_WATCHER": "1",

--- a/TavernHelios.Server/appsettings.Development.json
+++ b/TavernHelios.Server/appsettings.Development.json
@@ -7,14 +7,14 @@
   },
   "GrpcMenuServiceSettings": {
     //"Ip": "localhost",
-    "Ip": "host.docker.internal", //для запуска центрального сервиса из студии отдельно от docker compose
-    //"Ip": "menuservice", //если запускать всё в docker compose
+    //"Ip": "host.docker.internal", //для запуска центрального сервиса из студии отдельно от docker compose
+    "Ip": "menuservice", //если запускать всё в docker compose
     "Port": "5064"
   },
   "GrpcReservationServiceSettings": {
     //"Ip": "localhost",
-    "Ip": "host.docker.internal", //для запуска центрального сервиса из студии отдельно от docker compose
-    //"Ip": "reservationservice", //если запускать всё в docker compose 
+    //"Ip": "host.docker.internal", //для запуска центрального сервиса из студии отдельно от docker compose
+    "Ip": "reservationservice", //если запускать всё в docker compose 
     "Port": "5065"
   }
   // P.S. Как будто host.docker.internal тоже работает когда запускаем из докер композ

--- a/TavernHelios.Server/appsettings.Development.json
+++ b/TavernHelios.Server/appsettings.Development.json
@@ -17,6 +17,4 @@
     "Ip": "reservationservice", //если запускать всё в docker compose 
     "Port": "5065"
   }
-  // P.S. Как будто host.docker.internal тоже работает когда запускаем из докер композ
-
 }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,8 +3,15 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: "Development"
       ASPNETCORE_URLS: "https://+:5555"
-  
+    networks:
+      - app_network      
+    
   client:
     environment:
       VITE_API_URL: "https://localhost:5555"
       NODE_ENV: "development"
+
+
+networks:
+  app_network:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,9 +107,9 @@ services:
       - ./nginx/conf.d:/etc/nginx/conf.d
       - ./nginx/ssl:/etc/nginx/ssl
       
-networks:
-  app_network:
-    driver: bridge     
+# networks:
+#   app_network:
+#     driver: bridge     
 
 volumes:
   mongo_data:

--- a/tavernhelios.client/vite.config.ts
+++ b/tavernhelios.client/vite.config.ts
@@ -23,7 +23,7 @@ console.log("KEY:", keyFilePath);
 console.log("NODE_ENV from process:", env.NODE_ENV);
 console.log("VITE_API_URL from process:", env.VITE_API_URL);
 
-const target = env.VITE_API_URL || `http://178.72.83.217:32040`;
+const target = env.VITE_API_URL || `https://178.72.83.217:32040`;
 // const target = env.VITE_API_URL 
 //     || (!isDocker ? `https://localhost:5555` : `http://178.72.83.217:32040`);
 

--- a/tavernhelios.client/vite.config.ts
+++ b/tavernhelios.client/vite.config.ts
@@ -23,7 +23,7 @@ console.log("KEY:", keyFilePath);
 console.log("NODE_ENV from process:", env.NODE_ENV);
 console.log("VITE_API_URL from process:", env.VITE_API_URL);
 
-const target = env.VITE_API_URL || `https://178.72.83.217:32040`;
+const target = env.VITE_API_URL || `http://178.72.83.217:32040`;
 // const target = env.VITE_API_URL 
 //     || (!isDocker ? `https://localhost:5555` : `http://178.72.83.217:32040`);
 

--- a/tavernhelios.client/vite.config.ts
+++ b/tavernhelios.client/vite.config.ts
@@ -23,9 +23,9 @@ console.log("KEY:", keyFilePath);
 console.log("NODE_ENV from process:", env.NODE_ENV);
 console.log("VITE_API_URL from process:", env.VITE_API_URL);
 
-const target = env.VITE_API_URL || `http://178.72.83.217:32040`;
-// const target = env.VITE_API_URL 
-//     || (!isDocker ? `https://localhost:5555` : `http://178.72.83.217:32040`);
+// const target = env.VITE_API_URL || `http://178.72.83.217:32040`;
+const target = env.VITE_API_URL 
+    || (!isDocker ? `https://localhost:5555` : `http://178.72.83.217:32040`);
 
 console.log("API Target:", target);
 

--- a/tavernhelios.client/vite.config.ts
+++ b/tavernhelios.client/vite.config.ts
@@ -23,9 +23,9 @@ console.log("KEY:", keyFilePath);
 console.log("NODE_ENV from process:", env.NODE_ENV);
 console.log("VITE_API_URL from process:", env.VITE_API_URL);
 
-// const target = env.VITE_API_URL || `http://178.72.83.217:32040`;
-const target = env.VITE_API_URL 
-    || (!isDocker ? `https://localhost:5555` : `http://178.72.83.217:32040`);
+const target = env.VITE_API_URL || `http://178.72.83.217:32040`;
+// const target = env.VITE_API_URL 
+//     || (!isDocker ? `https://localhost:5555` : `http://178.72.83.217:32040`);
 
 console.log("API Target:", target);
 


### PR DESCRIPTION

### Изменения:
#### Prod
- После множества манипуляций удалось запустить прод. Теперь конфигурации едины.

#### Local
- Docker-compose теперь запускает все сервисы. Для этого необходимо сначала создать external сеть в Docker: 
  `docker network create --driver bridge --attachable app_network`
- В центральном сервисе для работы через HTTPS нужно изменить IP на `host.docker.internal` в appsettings. он запускается вместе с фронтом автоматически.
- Для работы центрального сервиса в контейнере из Visual Studio, после поднятия контейнера, нужно подключить к внутренней сети приложения из Docker Compose:
  `docker network connect app_network TavernHelios.Server_X` (где TavernHelios.Server_X — имя контейнера, созданного студией).
- Настроено так, что локально:
  - Центральный бэк работает на https://localhost:5555/swagger
  - Фронт работает на https://localhost:8888